### PR TITLE
Fixing two bugs

### DIFF
--- a/plumlightpad/lightpad.py
+++ b/plumlightpad/lightpad.py
@@ -144,17 +144,17 @@ class Lightpad(object):
                 "white": w
             }
         }
-        return await self.async_set_config(config=config)
+        return await self.set_config(config=config)
 
     async def set_glow_timeout(self, timeout):
         if timeout >= 0:
             config = {"glowTimeout": timeout}
-            await self.async_set_config(config=config)
+            await self.set_config(config=config)
 
     async def set_glow_intensity(self, intensity):
         if intensity >= 0:
             config = {"glowIntensity": (float(intensity) / float(100))}
-            await self.async_set_config(config=config)
+            await self.set_config(config=config)
 
     async def enable_glow(self):
         await self.__enable_glow(True)
@@ -163,7 +163,7 @@ class Lightpad(object):
         await self.__enable_glow(False)
 
     async def __enable_glow(self, enable):
-        await self.async_set_config({"glowEnabled": enable})
+        await self.set_config({"glowEnabled": enable})
 
     async def set_config(self, config):
         llid = self.llid

--- a/plumlightpad/logicalload.py
+++ b/plumlightpad/logicalload.py
@@ -35,7 +35,7 @@ class LogicalLoad(object):
 
     @property
     def dimmable(self):
-        return bool(self.primaryLightpad.glow_enabled)
+        return bool(self.primaryLightpad.config['dimEnabled'])
 
     @property
     def level(self):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ PACKAGE_NAME = 'plumlightpad'
 
 setup(
     name = PACKAGE_NAME,
-    version = "0.0.11",
+    version = "0.0.12",
     author = "Heath Paddock",
     author_email = "hp@heathpaddock.com",
     description = ("A python package that interacts with the Plum Lightpad"),


### PR DESCRIPTION
This PR fixes two bugs:

- Method naming issue - it's `set_config` not `async_set_config`
- Logical Load dimming should be driven by the Lightpad config not the glow ring's glow